### PR TITLE
fix missing var + consolidate output_path computation + fix error concatenating userdata

### DIFF
--- a/local-stream-marker.lua
+++ b/local-stream-marker.lua
@@ -57,6 +57,7 @@ local last_recording_frame_count		= 0
 local last_stream_frame_count			= 0
 
 -- functions and all that
+local update_output_path
 local read_local_stream_marker_csv_file
 local read_all_lines
 local write_all_lines
@@ -84,7 +85,7 @@ local print_log
 
 
 -----== FILES SECTION ==-----
-read_local_stream_marker_csv_file = function()
+update_output_path = function()
 	-- check if using custom filename
 	local output_file_name_actual = set_filename(output_file_name_current)
 
@@ -100,6 +101,10 @@ read_local_stream_marker_csv_file = function()
 	if (output_folder ~= "" and file_exists(output_folder)) then
 		output_path = output_folder .. "/" .. output_file_name_actual
 	end
+end
+
+read_local_stream_marker_csv_file = function()
+	update_output_path()
 
 	return obs.os_quick_read_utf8_file(output_path);
 end
@@ -548,13 +553,7 @@ get_all_comment_preset_files = function()
 	print_log("--- Searching for comment preset files in: " .. script_path() .. " ---")
 	preset_filenames = {}
 
-	-- set output path as the script path by default
-	output_path = script_path() .. output_file_name_actual;
-
-	-- if specified output path exists, then set this as the new output path
-	if (output_folder ~= "" and file_exists(output_folder)) then
-		output_path = output_folder .. "/" .. output_file_name_actual
-	end
+	update_output_path()
 	
 	local dir = obs.os_opendir(output_folder)
 	if dir then

--- a/local-stream-marker.lua
+++ b/local-stream-marker.lua
@@ -335,7 +335,7 @@ mark_stream = function(active_comment)
     open_markers[active_comment] = open_markers[active_comment] or {}
     table.insert(open_markers[active_comment], #lines)
 
-	print_log("START '" .. active_comment .. "' → row " .. #lines)
+	print_log("START '" .. tostring(active_comment) .. "' → row " .. #lines)
 	return true;
 end
 
@@ -388,7 +388,7 @@ mark_end_stream = function(active_comment)
 
 	local queue = open_markers[active_comment]
 	if not queue or #queue == 0 then
-		print_log("END ignored: no open marker for '" .. active_comment .. "'")
+		print_log("END ignored: no open marker for '" .. tostring(active_comment) .. "'")
 		return
 	end
 
@@ -412,7 +412,7 @@ mark_end_stream = function(active_comment)
 	lines[row_index] = table.concat(fields, ", ")
 	write_all_lines(output_path, lines)
 
-	print_log("END '" .. active_comment .. "' → row " .. row_index)
+	print_log("END '" .. tostring(active_comment) .. "' → row " .. row_index)
 	return true;
 end
 


### PR DESCRIPTION
thx so much for making this! it's a great plugin :3

in trying to get the script up and running locally i encountered two issues:
1. a function was trying to use `output_file_name_actual` but it was not defined
2. the logging code was concatenating strings and `active_comment`, which is not a simple string but rather a userdata value

given that `output_file_name_actual` was just used to update `output_path`, i killed two birds with one stone and solved no. 1 by extracting the logic for computing `output_path` into a shared function

then i solved no. 2 by converting `active_comment` to a string before concatenating

i have not thoroughly tested the script so it's possible there were more errors i did not cover, but these fixes were all i had the time for atm